### PR TITLE
Fix error with python 3.8 and np.load.

### DIFF
--- a/source/dataset.py
+++ b/source/dataset.py
@@ -18,7 +18,7 @@ class BaseDataset(object):
     Acts as a data container. Loads and parses data, and provides basic functionality.
     """
     def __init__(self, data_path):
-        self.data_dict = dict(np.load(data_path))
+        self.data_dict = dict(np.load(data_path, allow_pickle=True))
 
     @property
     def num_samples(self):


### PR DESCRIPTION
Otherwise it will not work anymore:

```bash
python visualize_hw.py -D ./data/deepwriting_validation.npz -O ./data_images -S 1 5 20
./data/deepwriting_validation.npz
Traceback (most recent call last):
  File "visualize_hw.py", line 172, in <module>
    visualize_sample(args)
  File "visualize_hw.py", line 151, in visualize_sample
    dataset = Dataset(args.data_file)
  File ".../PycharmProjects/deepwriting/dataset_hw.py", line 250, in __init__
    super(HandWritingDatasetConditional, self).__init__(data_path, var_len_seq)
  File ".../PycharmProjects/deepwriting/dataset_hw.py", line 23, in __init__
    super(HandWritingDataset, self).__init__(data_path)
  File ".../PycharmProjects/deepwriting/source/dataset.py", line 22, in __init__
    self.data_dict = dict(np.load(data_path))
  File "/usr/lib/python3.8/site-packages/numpy/lib/npyio.py", line 253, in __getitem__
    return format.read_array(bytes,
  File "/usr/lib/python3.8/site-packages/numpy/lib/format.py", line 727, in read_array
    raise ValueError("Object arrays cannot be loaded when "
ValueError: Object arrays cannot be loaded when allow_pickle=False
```
